### PR TITLE
Remove `absl::container` from CMakeList.txt.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,7 +124,7 @@ INCLUDE_DIRECTORIES(.)
 SET(LIBROBOTS_LIBS)
 
 SET(robots_SRCS ./robots.cc)
-SET(robots_LIBS absl::base absl::container absl::strings)
+SET(robots_LIBS absl::base absl::strings)
 
 ADD_LIBRARY(robots SHARED ${robots_SRCS})
 TARGET_LINK_LIBRARIES(robots ${robots_LIBS})


### PR DESCRIPTION
It is not used and it doesn't build after latest change in abseil
See https://github.com/abseil/abseil-cpp/commit/a76698790753d2ec71f655cdc84d61bcb27780d4

Fixes #34

PiperOrigin-RevId: 360377366